### PR TITLE
Revisions to Pit Room G-mode strats

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2492,17 +2492,19 @@
                   "hits": 1
                 }
               },
-              "f_ZebesAwake"
-            ]
+              "Missile",
+              "Morph"
+            ],
+            "note": "The enemies do not spawn in this room unless Missiles and Morph are collected (even if Zebes is awake)."
           },
           "locks": [
             {
               "name": "Pit Room Right Grey Lock (to Elevator)",
               "lockType": "killEnemies",
               "lock": [
-                    "Missile",
-                    "Morph"
-                  ],
+                "Missile",
+                "Morph"
+              ],
               "unlockStrats": [
                 {
                   "name": "Base",
@@ -2596,7 +2598,7 @@
                   "note": "Breaking the side blocks can be done with a shinespark, or by moving into them once past the solid blocks."
                 },
                 {
-                  "name": "G-Mode Morph to break Bomb Blocks",
+                  "name": "G-Mode Morph to Bomb the Bomb Blocks",
                   "notable": false, 
                   "requires": [
                     {"comeInWithGMode": {
@@ -2604,15 +2606,32 @@
                       "mode": "any",
                       "artificialMorph": true
                     }},
-                    {"or": [
-                      "Bombs",
-                    {"and": [
-                      "Powerbombs",
-                      {"ammo": {"type": "PowerBomb", "count": 1}}
-                    ]}
-                    ]}
-                    ]
-                  }
+                    "Bombs"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
+                    "When the bomb blocks turn to air, lay bombs as Samus falls.",
+                    "After landing on the first platform, quickly unmorph and use X-ray to cancel G-mode before the bombs explode."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph to Power Bomb the Bomb Blocks",
+                  "notable": false, 
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [1],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "PowerBomb",
+                    {"ammo": {"type": "PowerBomb", "count": 1}}
+                  ],
+                  "note": [
+                    "As soon as you enter the room, lay a Power Bomb to break the bomb blocks leading down to the item.",
+                    "After the Pirate is destroyed, move to the right to a location safe from the path of the lasers.",
+                    "Then unmorph and use X-ray to cancel G-mode, which will clear the blocks."
+                  ]
+                }
               ]
             }
           ]
@@ -2633,29 +2652,61 @@
             {
               "id": 3,
               "strats": [
-              {
-                "name": "G-Mode to break Bomb Blocks",
-                "notable": false,
-                "requires": [
-                  {"comeInWithGMode": {
-                    "fromNodes": [2],
-                    "mode": "any",
-                    "artificialMorph": true
-                  }},
-                  {"or": [
-                    "Bombs",
-                    {"and": [
-                      "Powerbombs",
-                      {"ammo": {"type": "PowerBomb", "count": 5}}
-                    ]},
-                    {"and": [
-                      "Springball",
-                      "Powerbombs",
-                      {"ammo": {"type": "PowerBomb", "count": 1}}
-                    ]}
-                  ]}
-                ]
-              }
+                {
+                  "name": "G-Mode Morph to Bomb the Bomb Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "Bombs"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block directly above the bomb block leading down to the item.",
+                    "When the bomb blocks turn to air, lay bombs as Samus falls.",
+                    "After landing on the first platform, quickly unmorph and use X-Ray to cancel G-mode before the bombs explode."
+                  ]
+                },
+                {
+                  "name": "G-Mode Morph to Power Bomb the Bomb Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "PowerBomb",
+                    {"ammo": {"type": "PowerBomb", "count": 5}}
+                  ],
+                  "note": [
+                    "Use Power Bomb horizontal boosts to move toward the left side of the room in artificial morph.",
+                    "Roll off the second-to-last blue platform and lay a Power Bomb against the wall to get into range of the bomb blocks.",
+                    "Then unmorph and use X-ray to cancel G-mode, which will clear the blocks."
+                  ],
+                  "devNote": "FIXME: add canBombHorizontally tech after Morph requirement is removed from it."
+                },
+                {
+                  "name": "G-Mode Morph Spring Ball to Power Bomb the Bomb Blocks",
+                  "notable": false,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [2],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "SpringBall",
+                    "PowerBomb",
+                    {"ammo": {"type": "PowerBomb", "count": 1}}
+                  ],
+                  "note": [
+                    "Use SpringBall to go under the Pirates and reach the left side of the room in artificial morph.",
+                    "Use a Power Bomb to break the bomb blocks.",
+                    "Unmorph and use X-ray to cancel G-mode, which will clear the blocks."
+                  ]
+                }
               ]
             }
           ]


### PR DESCRIPTION
- Corrected the requirement in gModeImmobile for the enemies to spawn.
- Fixed some requirement references: "Powerbombs" -> "PowerBomb", "Springball" -> "SpringBall".
- Fixed some indentation
- Split apart the G-mode strats in order to give specific notes for the different cases. In general it's fine to use "or" to lump minor movement variations together (e.g. with vs. without SpringBall, Bombs vs. Power Bombs) but in this case the movement seems tricky enough that separate notes can be helpful.

Also, could you rename the pull request to include the name of the room? It can help make these easier to keep track of.