### PR TITLE
revisions for Climb G-mode strats

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -2120,6 +2120,11 @@
         {
           "name": "Climb Behemoth Shinespark",
           "note": "Diagonal shinespark up the climb to break the bomb blocks to the morph tunnels on the right. For the top block, spark from a crouch."
+        },
+        {
+          "name": "Climb G-Mode Morph BobBob IBJ to Top",
+          "note": "Using IBJ to get from to bottom to the top of Climb without unmorphing. Precise timing and enemy manipulations are required to reach the top without taking a hit.",
+          "devNote": "BobBob video: https://vimeo.com/815933967"
         }
       ],
       "links": [
@@ -2130,15 +2135,16 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "Fall down Climb, then go through bomb blocks",
+                  "name": "G-Mode through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "mode": "any",
-                      "artificialMorph": true
+                      "artificialMorph": false
                     }}
-                  ]
+                  ],
+                  "note": "Overload PLMs using scroll blocks a few tiles in front of the bomb blocks."
                 }
               ]
             },
@@ -2146,7 +2152,7 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Bomb or Jump Diagonally to Bomb Blocks",
+                  "name": "G-Mode Morph through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -2155,25 +2161,27 @@
                       "artificialMorph": true
                     }},
                     "h_canArtificialMorphMovement"
-                  ]
+                  ],
+                  "note": "Overload PLMs using the scroll block next to the bomb blocks."
                 }
               ]
             },
-              {
-                "id": 4,
-                "strats": [
-                  {
-                    "name": "Fall down towards bomb blocks",
-                    "notable": false,
-                    "requires": [
+            {
+              "id": 4,
+              "strats": [
+                {
+                  "name": "G-Mode Morph through Bomb Blocks",
+                  "notable": false,
+                  "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [1],
                       "mode": "any",
-                      "artificialMorph": false
+                      "artificialMorph": true
                     }}
-                    ]
-                  }
-                ]
+                  ],
+                  "note": "Overload PLMs using the scroll block next to the bomb blocks."
+                }
+              ]
             },
             {
               "id": 6,
@@ -2194,7 +2202,7 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Climb Climb offscreen to top",
+                  "name": "Climb G-Mode Morph Blind Climb to the Top",
                   "notable": true,
                   "requires": [
                     "h_canArtificialMorphMovement",
@@ -2206,7 +2214,9 @@
                     "canOffScreenMovement"
                   ],
                   "note": [
-                    "You need to climb Climb while navagating offscreen, up to the bomb blocks."
+                    "Overload PLMs using the scroll blocks next to the bomb wall",
+                    "After passing through, you need to go from the bottom to the top of Climb and into the bomb blocks while still in G-mode Morph.",
+                    "Samus will not be visible at all; the only available feedback is audio and position on the map."
                   ]
                 }
               ]
@@ -2215,7 +2225,7 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Climb Climb offscreen",
+                  "name": "G-Mode Morph Blind",
                   "notable": false,
                   "requires": [
                     "h_canArtificialMorphMovement",
@@ -2225,6 +2235,12 @@
                       "artificialMorph": true
                     }},
                     "canOffScreenMovement"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll blocks next to the bomb wall",
+                    "Navigate to the lower right bomb blocks while still morphed.",
+                    "Samus will be off-camera and not visible, requiring blind movement.",
+                    "Enemies will not hurt Samus since they are non-global and also off-camera."
                   ]
                 }
               ]
@@ -2287,7 +2303,8 @@
                       "mode": "any",
                       "artificialMorph": false
                     }}
-                  ]
+                  ],
+                  "note": "Overload PLMs using the scroll blocks immediately in front of the bomb wall"
                 },
                 {
                   "name": "Zebes Ablaze",
@@ -2312,15 +2329,19 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "fall down Climb",
+                  "name": "G-Mode through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [3],
                       "mode": "any",
-                      "artificialMorph": false
+                      "artificialMorph": true
                     }},
                     "h_canArtificialMorphMovement"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
+                    "Reach the bottom and pass through the bomb blocks while still in G-mode."
                   ]
                 }
               ]
@@ -2329,7 +2350,7 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "fall down Climb",
+                  "name": "G-Mode Morph through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     "h_canArtificialMorphMovement",
@@ -2337,8 +2358,11 @@
                       "fromNodes": [3],
                       "mode": "any",
                       "artificialMorph": true
-                    }},
-                    "canOffScreenMovement"
+                    }}
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs immediately in front of the bomb blocks.",
+                    "Fall down to the lower bomb blocks while still in G-mode Morph."
                   ]
                 }
               ]
@@ -2352,7 +2376,7 @@
                   "requires": [ "h_canBombThings" ]
                 },
                 {
-                  "name": "G-Mode Morph Through Bomb Blocks",
+                  "name": "G-Mode Morph through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     "h_canArtificialMorphMovement",
@@ -2361,6 +2385,9 @@
                       "mode": "any",
                       "artificialMorph": true
                     }}
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks."
                   ]
                 }
               ]
@@ -2381,7 +2408,12 @@
                       "fromNodes": [4],
                       "mode": "any",
                       "artificialMorph": true
-                    }}
+                    }},
+                    "h_canArtificialMorphMovement"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
+                    "Fall down and pass through bomb wall at the bottom while still in G-mode."
                   ]
                 }
               ]
@@ -2390,19 +2422,39 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Climb up from the side",
+                  "name": "G-Mode Morph",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
-                      "fromNodes": [5],
+                      "fromNodes": [4],
                       "mode": "any",
                       "artificialMorph": true
                     }},
                     {"or": [
                       "SpringBall",
-                      "Morph",
-                      "canBobJump"
+                      "Morph"
                     ]}
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
+                    "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit or unmorphing."
+                  ]
+                },
+                {
+                  "name": "Climb G-Mode Morph BobBob IBJ to Top (from Crateria Supers Bottom)",
+                  "notable": true,
+                  "requires": [
+                    "h_canArtificialMorphIBJ",
+                    {"comeInWithGMode": {
+                      "fromNodes": [4],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }}
+                  ],
+                  "reusableRoomwideNotable": "Climb G-Mode Morph BobBob IBJ to Top",
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks.",
+                    "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit."
                   ]
                 }
               ]
@@ -2416,15 +2468,15 @@
                   "requires": [ "h_canBombThings" ]
                 },
                 {
-                  "name": "G-Mode Morph Through Bomb Blocks",
+                  "name": "G-Mode Morph through Bomb Blocks",
                   "notable": false,
                   "requires": [
-                    "h_canArtificialMorphMovement",
                     {"comeInWithGMode": {
-                      "fromNodes": [3],
+                      "fromNodes": [4],
                       "mode": "any",
                       "artificialMorph": true
-                    }}
+                    }},
+                    "h_canArtificialMorphMovement"
                   ]
                 }
               ]
@@ -2438,7 +2490,7 @@
               "id": 2,
               "strats": [
                 {
-                  "name": "G-mode through Bomb Blocks",
+                  "name": "G-Mode through Bomb Blocks",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -2454,8 +2506,8 @@
               "id": 3,
               "strats": [
                 {
-                  "name": "Dodge enemy climb",
-                  "notable": true,
+                  "name": "G-Mode Morph",
+                  "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
                       "fromNodes": [5],
@@ -2464,9 +2516,29 @@
                     }},
                     {"or": [
                       "SpringBall",
-                      "Morph",
-                      "canBobJump"
+                      "Morph"
                     ]}
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block at the top of the stairs next to the bomb blocks, allowing passage through the bomb blocks by making them become air.",
+                    "If Morph is not available, careful movement is needed with SpringBall to reach the top without taking a hit or unmorphing."
+                  ]
+                },
+                {
+                  "name": "Climb G-Mode Morph BobBob IBJ to Top (from Pit Room)",
+                  "notable": true,
+                  "requires": [
+                    {"comeInWithGMode": {
+                      "fromNodes": [5],
+                      "mode": "any",
+                      "artificialMorph": true
+                    }},
+                    "h_canArtificialMorphIBJ"
+                  ],
+                  "reusableRoomwideNotable": "Climb G-Mode Morph BobBob IBJ to Top",
+                  "note": [
+                    "A long series of precise bomb jumps and enemy manipulations are required to reach the top without taking a hit or unmorphing.",
+                    "Overload PLMs using the scroll block next to the bomb blocks at the top, allowing passage through them by making them become air."
                   ]
                 }
               ]
@@ -2475,7 +2547,7 @@
               "id": 4,
               "strats": [
                 {
-                  "name": "Easy Enemy dodge climb",
+                  "name": "G-Mode Morph",
                   "notable": false,
                   "requires": [
                     {"comeInWithGMode": {
@@ -2484,6 +2556,10 @@
                       "artificialMorph": true
                     }},
                     "h_canArtificialMorphMovement"
+                  ],
+                  "note": [
+                    "Overload PLMs using the scroll block next to the bottom right bomb blocks, allowing passage through them by making them become air.",
+                    "If Morph is unavailable, then careful movement will be required to get past the Pirates without take a hit."
                   ]
                 }
               ]
@@ -2563,18 +2639,6 @@
                   ]
                 },
                 {
-                  "name": "G-Mode through Bomb Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1, 5],
-                      "mode": "any",
-                      "artificialMorph": false
-                    }}
-                  ],
-                  "note": "The Scroll Blocks are above and to the left of the Bomb Blocks. You can overload them by repeatedly jumping or walking 2-3 blocks to the right."
-                },
-                {
                   "name": "Zebes Ablaze",
                   "notable": false,
                   "requires": [],
@@ -2595,15 +2659,6 @@
                   "name": "Base",
                   "notable": false,
                   "requires": ["h_canBombThings"]
-                },
-                {
-                  "name": "Climb Climb with G-mode Morph",
-                  "notable": false,
-                  "requires": [
-                    "Morph",
-                    "SpringBall",
-                    "canBobJump"
-                  ]
                 },
                 {
                   "name": "Behemoth Spark Top",
@@ -2658,17 +2713,6 @@
                   "note": [
                     "The bomb blocks can be broken by spinjumping with Screw attack and holding right, if moonfall makes Samus clip through the platform.",
                     "Use the small blue platform 2nd from the top on the right side."
-                  ]
-                },
-                {
-                  "name": "G-Mode Morph through Bomb Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1, 5],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }}
                   ]
                 }
               ]


### PR DESCRIPTION
- some corrections to "artificialMorph" and "fromNodes" values
- adjustments to strat names
- split off reusable notable strat for "Climb G-Mode Morph BobBob IBJ to Top" (instead of "canBobJump" tech)
- add notes to describe how to execute the strats (including where relevant scroll PLMs are located).
- remove g-mode strats starting from node 6 since these ended up being covered by strats from nodes 1 and 5.