### PR TITLE
Remove PB strat

### DIFF
--- a/region/crateria/central.json
+++ b/region/crateria/central.json
@@ -3195,19 +3195,6 @@
                   "name": "Base",
                   "notable": false,
                   "requires": [ "Morph" ]
-                },
-                {
-                  "name": "G-mode Morph to Powerbomb Bomb Blocks",
-                  "notable": false,
-                  "requires": [
-                    {"comeInWithGMode": {
-                      "fromNodes": [1],
-                      "mode": "any",
-                      "artificialMorph": true
-                    }},
-                    "PowerBomb",
-                    {"ammo": {"type": "PowerBomb", "count": 1}}
-                  ]
                 }
               ]
             }
@@ -3234,7 +3221,8 @@
                       "artificialMorph": true
                     }},
                     "Bombs"
-                  ]
+                  ],
+                  "note": "Repeatedly bomb the crumble blocks until the PLMs are overloaded."
                 }
               ]
             }


### PR DESCRIPTION
Removed the PB strat. Assuming I am understanding it correctly, this would still require morph, and if that is the case, the g-mode strat is no longer useful.

Added a description to the R->L bomb strat